### PR TITLE
Preview nodes

### DIFF
--- a/demo/2d/demo_2d.tscn
+++ b/demo/2d/demo_2d.tscn
@@ -35,6 +35,7 @@ __meta__ = {
 "_edit_group_": true
 }
 zone_path = "res://demo/2d/zones/zone_01.tscn"
+preview = false
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="ZoneLoader/Zone01"]
 shape = SubResource( 1 )
@@ -48,6 +49,7 @@ __meta__ = {
 "_edit_group_": true
 }
 zone_path = "res://demo/2d/zones/zone_02.tscn"
+preview = false
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="ZoneLoader/Zone02"]
 shape = SubResource( 2 )
@@ -61,6 +63,7 @@ __meta__ = {
 "_edit_group_": true
 }
 zone_path = "res://demo/2d/zones/zone_03.tscn"
+preview = false
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="ZoneLoader/Zone03"]
 shape = SubResource( 3 )
@@ -74,6 +77,7 @@ __meta__ = {
 "_edit_group_": true
 }
 zone_path = "res://demo/2d/zones/zone_04.tscn"
+preview = false
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="ZoneLoader/Zone04"]
 shape = SubResource( 4 )

--- a/demo/2d/demo_2d.tscn
+++ b/demo/2d/demo_2d.tscn
@@ -35,7 +35,7 @@ __meta__ = {
 "_edit_group_": true
 }
 zone_path = "res://demo/2d/zones/zone_01.tscn"
-preview = false
+preview = true
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="ZoneLoader/Zone01"]
 shape = SubResource( 1 )
@@ -49,7 +49,7 @@ __meta__ = {
 "_edit_group_": true
 }
 zone_path = "res://demo/2d/zones/zone_02.tscn"
-preview = false
+preview = true
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="ZoneLoader/Zone02"]
 shape = SubResource( 2 )
@@ -63,7 +63,7 @@ __meta__ = {
 "_edit_group_": true
 }
 zone_path = "res://demo/2d/zones/zone_03.tscn"
-preview = false
+preview = true
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="ZoneLoader/Zone03"]
 shape = SubResource( 3 )
@@ -77,7 +77,7 @@ __meta__ = {
 "_edit_group_": true
 }
 zone_path = "res://demo/2d/zones/zone_04.tscn"
-preview = false
+preview = true
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="ZoneLoader/Zone04"]
 shape = SubResource( 4 )

--- a/demo/3d/demo_3d.tscn
+++ b/demo/3d/demo_3d.tscn
@@ -41,7 +41,7 @@ collision_layer = 2
 collision_mask = 2
 script = ExtResource( 1 )
 zone_path = "res://demo/3d/zones/zone_01.tscn"
-preview = false
+preview = true
 
 [node name="CollisionShape" type="CollisionShape" parent="ZoneLoader/Zone01"]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -18.8995 )
@@ -53,7 +53,7 @@ collision_layer = 2
 collision_mask = 2
 script = ExtResource( 1 )
 zone_path = "res://demo/3d/zones/zone_02.tscn"
-preview = false
+preview = true
 
 [node name="CollisionShape" type="CollisionShape" parent="ZoneLoader/Zone02"]
 shape = SubResource( 2 )
@@ -72,7 +72,7 @@ collision_layer = 2
 collision_mask = 2
 script = ExtResource( 1 )
 zone_path = "res://demo/3d/zones/zone_03.tscn"
-preview = false
+preview = true
 
 [node name="CollisionShape" type="CollisionShape" parent="ZoneLoader/Zone03"]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 103.504, 0, 0 )

--- a/demo/3d/demo_3d.tscn
+++ b/demo/3d/demo_3d.tscn
@@ -41,6 +41,7 @@ collision_layer = 2
 collision_mask = 2
 script = ExtResource( 1 )
 zone_path = "res://demo/3d/zones/zone_01.tscn"
+preview = false
 
 [node name="CollisionShape" type="CollisionShape" parent="ZoneLoader/Zone01"]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -18.8995 )
@@ -52,6 +53,7 @@ collision_layer = 2
 collision_mask = 2
 script = ExtResource( 1 )
 zone_path = "res://demo/3d/zones/zone_02.tscn"
+preview = false
 
 [node name="CollisionShape" type="CollisionShape" parent="ZoneLoader/Zone02"]
 shape = SubResource( 2 )
@@ -70,6 +72,7 @@ collision_layer = 2
 collision_mask = 2
 script = ExtResource( 1 )
 zone_path = "res://demo/3d/zones/zone_03.tscn"
+preview = false
 
 [node name="CollisionShape" type="CollisionShape" parent="ZoneLoader/Zone03"]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 103.504, 0, 0 )

--- a/demo/3d/zones/zone_01.tscn
+++ b/demo/3d/zones/zone_01.tscn
@@ -1,12 +1,13 @@
-[gd_scene load_steps=5 format=2]
+[gd_scene load_steps=6 format=2]
 
 [ext_resource path="res://demo/3d/zones/resources/rock.tscn" type="PackedScene" id=1]
 [ext_resource path="res://demo/3d/zones/resources/materials/terrain_green.material" type="Material" id=2]
 [ext_resource path="res://demo/3d/zones/resources/materials/rock_white.material" type="Material" id=3]
 [ext_resource path="res://demo/3d/resources/player_spawn.tscn" type="PackedScene" id=4]
-
+[ext_resource path="res://scripts/on_ready.gd" type="Script" id=5]
 
 [node name="Zone01" type="Spatial"]
+script = ExtResource( 5 )
 
 [node name="PlayerSpawn" parent="." instance=ExtResource( 4 )]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 2.76064, 0 )

--- a/demo/3d/zones/zone_02.tscn
+++ b/demo/3d/zones/zone_02.tscn
@@ -1,15 +1,12 @@
-[gd_scene load_steps=4 format=2]
+[gd_scene load_steps=5 format=2]
 
 [ext_resource path="res://demo/3d/zones/resources/materials/terrain_orange.material" type="Material" id=1]
 [ext_resource path="res://demo/3d/zones/resources/rock.tscn" type="PackedScene" id=2]
 [ext_resource path="res://demo/3d/resources/player_spawn.tscn" type="PackedScene" id=3]
-
-
-
-
-
+[ext_resource path="res://scripts/on_ready.gd" type="Script" id=4]
 
 [node name="Zone02" type="Spatial"]
+script = ExtResource( 4 )
 
 [node name="PlayerSpawn" parent="." instance=ExtResource( 3 )]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 4.40869, 0 )

--- a/demo/3d/zones/zone_03.tscn
+++ b/demo/3d/zones/zone_03.tscn
@@ -1,13 +1,9 @@
-[gd_scene load_steps=7 format=2]
+[gd_scene load_steps=8 format=2]
 
 [ext_resource path="res://demo/3d/zones/resources/rock.tscn" type="PackedScene" id=1]
 [ext_resource path="res://demo/3d/zones/resources/materials/terrain_blue.material" type="Material" id=2]
 [ext_resource path="res://demo/3d/resources/player_spawn.tscn" type="PackedScene" id=3]
-
-
-
-
-
+[ext_resource path="res://scripts/on_ready.gd" type="Script" id=4]
 
 [sub_resource type="CubeMesh" id=1]
 
@@ -18,6 +14,7 @@ roughness = 0.62
 [sub_resource type="BoxShape" id=3]
 
 [node name="Zone03" type="Spatial"]
+script = ExtResource( 4 )
 
 [node name="PlayerSpawn" parent="." instance=ExtResource( 3 )]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 191, 7.82312, 0 )

--- a/scripts/on_ready.gd
+++ b/scripts/on_ready.gd
@@ -1,0 +1,4 @@
+extends Spatial
+
+func _ready():
+	prints(name, "ready")

--- a/scripts/zone_trigger.gd
+++ b/scripts/zone_trigger.gd
@@ -5,8 +5,11 @@ signal zone_entered(zone_id, zone_path)
 signal zone_exited(zone_id)
 
 export (String, FILE) var zone_path
+export (bool) var preview := false setget set_preview
 
 var zone_id
+var _preview_node: Node = null
+
 
 func _get_configuration_warning():
 	var this = self
@@ -14,24 +17,49 @@ func _get_configuration_warning():
 		return "ZoneTrigger must be an Area(2D) node"
 	return ""
 
+
 func _ready():
 	if Engine.editor_hint:
 		return
 	zone_id = self.name
-	
+
 	# warning-ignore:return_value_discarded
 	connect("body_entered", self, "zone_entered")
 	# warning-ignore:return_value_discarded
 	connect("body_exited", self, "zone_exited")
+
 
 # warning-ignore:unused_argument
 func zone_entered(player):
 	if Engine.editor_hint:
 		return
 	emit_signal("zone_entered", zone_id, zone_path)
-	
+
+
 # warning-ignore:unused_argument
 func zone_exited(player):
 	if Engine.editor_hint:
 		return
 	emit_signal("zone_exited", zone_id)
+
+
+func set_preview(value: bool):
+	if not Engine.editor_hint || preview == value:
+		return
+	preview = value
+
+	# remove existing node, if any
+	if _preview_node:
+		_preview_node.queue_free()
+		_preview_node = null
+
+	# try to load the path
+	if preview && zone_path:
+		var scene: PackedScene = load(zone_path)
+		# if we loaded something, add it
+		if not scene:
+			return
+		_preview_node = scene.instance()
+		add_child(_preview_node)
+		# this node will not be saved in the editor
+		_preview_node.owner = null


### PR DESCRIPTION
This is a simple, non-optimized way to preview nodes. It works fine for the examples, at least.

Since it's just using `load()` and creating and destroying the scene whenever you toggle it, it's going to perform worse when the scenes are very intricate. For now, for me, it's fancy enough.

Key points are that the zone's scripts (saying "zone01 ready") only run in-game, as they aren't tools, and saving the scenes with previews enabled does _not_ include the preview nodes, just the flag used to set it in editor. So when you open the game, it's behaving exactly as before.